### PR TITLE
Added knowledge lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,3 +165,6 @@ Sacred](https://www.ratical.org/ratville/AoS/AbsenceOfTheSacred.txt)
 
 > no internet makes you significantly more productive than bad internet -- @feross
 
+## Other lists
+
+See [meta-knowledge](https://github.com/RichardLitt/meta-knowledge) for other lists like this on GitHub.


### PR DESCRIPTION
I've made a meta list of knowledge repos, because I have one too, and I didn't want to make everyone PR all of these knowledge lists. Having one place to have the lists makes more sense. 

I think your wisdom repo should be part of ours, because it does the same job. What do you think?